### PR TITLE
Fix/react-route-dom-with-vercel

### DIFF
--- a/client/vercel.json
+++ b/client/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites":  [
+    {"source": "/(.*)", "destination": "/"}
+  ]
+}

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -14,6 +14,7 @@ module.exports = {
   output: {
     filename: '[name].js',
     path: path.join(__dirname, '/dist'),
+    publicPath: '/',
   },
   resolve: {
     modules: ['node_modules'],


### PR DESCRIPTION
### 이슈 기록
vercel에서 react-router-dom을 사용하고자 한다면, 전달되는 모든 경로가 '/' 로 들어올 수 있도록 rewrites 해주어야 한다.
vercel.json을 추가하고 rewrites 해주었다.